### PR TITLE
Serve command: handling files not found

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ clap = { version = "3.1.2", default-features = false, features = [
 ] }
 fluent = "0.16.0"
 html5ever = "0.25.1"
+http-body = "0.4.4"
 hyper = { version = "0.14.17", features = ["client", "server", "tcp", "http1"] }
 hyper-tls = "0.5.0"
 intl-memoizer = "0.5.1"
@@ -33,7 +34,7 @@ tera = "1.15.0"
 time = { version = "0.3.7", features = ["serde", "serde-well-known"] }
 tokio = { version = "1.17.0", features = ["rt-multi-thread", "signal", "macros"] }
 toml = "0.5.8"
-tower = { version = "0.4.12", features = ["make"] }
+tower = { version = "0.4.12", features = ["make", "util"] }
 tower-http = { version = "0.2.3", features = ["fs"] }
 walkdir = "2.3.2"
 

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1,8 +1,11 @@
-use std::{env, net::SocketAddr, path::Path};
+use std::{env, io, net::SocketAddr, path::Path};
 
 use crate::{build::watch_build, TEMP_ZINE_BUILD_DIR};
 use anyhow::Result;
-use tower_http::services::ServeDir;
+use http_body::Full;
+use hyper::{body::HttpBody, Response, StatusCode};
+use tower::ServiceBuilder;
+use tower_http::services::{fs::ServeFileSystemResponseBody, ServeDir};
 
 static ZINE_BANNER: &str = r"
 
@@ -18,7 +21,26 @@ static ZINE_BANNER: &str = r"
 pub async fn run_serve(source: String, port: u16) -> Result<()> {
     let tmp_dir = env::temp_dir().join(TEMP_ZINE_BUILD_DIR);
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
-    let service = ServeDir::new(&tmp_dir);
+    let service = ServiceBuilder::new()
+        .and_then(
+            |response: Response<ServeFileSystemResponseBody>| async move {
+                let response = if response.status() == StatusCode::NOT_FOUND {
+                    let body = Full::from("404 Not Found")
+                        .map_err(|err| match err {})
+                        .boxed();
+                    Response::builder()
+                        .status(StatusCode::NOT_FOUND)
+                        .body(body)
+                        .unwrap()
+                } else {
+                    response.map(|body| body.boxed())
+                };
+
+                Ok::<_, io::Error>(response)
+            },
+        )
+        .service(ServeDir::new(&tmp_dir));
+
     tokio::spawn(async move {
         watch_build(Path::new(&source), tmp_dir.as_path(), true)
             .await


### PR DESCRIPTION
By default, `ServeDir` will return an empty 404 Not Found response if there is no file at the requested path.