### PR TITLE
Add word analysis

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ toml = "0.5.8"
 tower = { version = "0.4.12", features = ["make", "util"] }
 tower-http = { version = "0.2.3", features = ["fs"] }
 walkdir = "2.3.2"
+jieba-rs = "0.6"
 
 [dev-dependencies]
 test-case = "2"


### PR DESCRIPTION
In this pull request, the word analysis feature is added by using `jieba`.  We count all words whose length is greater than 1 and sort them in a B TreeMap. However, visualization is **not** implemented yet.

Signed-off-by: KernelErr <me@lirui.tech>