### PR TITLE
Speed up parsing and rendering

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,11 +17,15 @@ jobs:
     - name: Build
       run: |
         export PATH="$HOME/.cargo/bin:$PATH"
-        cargo build
+        cargo build --release
+    - name: Run clippy
+      run: |
+        export PATH="$HOME/.cargo/bin:$PATH"
+        cargo clippy --release
     - name: Run test
       run: |
         export PATH="$HOME/.cargo/bin:$PATH"
-        cargo test
+        cargo test --release
     - name: Publish test
       run: |
         export PATH="$HOME/.cargo/bin:$PATH"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,17 @@ notify = "4.0.17"
 once_cell = "1.10.0"
 parking_lot = "0.12.0"
 pulldown-cmark = "0.9.1"
+rayon = "1.5.1"
 regex = "1.5.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tera = "1.15.0"
 time = { version = "0.3.7", features = ["serde", "serde-well-known"] }
-tokio = { version = "1.17.0", features = ["rt-multi-thread", "signal", "macros"] }
+tokio = { version = "1.17.0", features = [
+    "rt-multi-thread",
+    "signal",
+    "macros",
+] }
 toml = "0.5.8"
 tower = { version = "0.4.12", features = ["make", "util"] }
 tower-http = { version = "0.2.3", features = ["fs"] }

--- a/src/build.rs
+++ b/src/build.rs
@@ -73,6 +73,6 @@ fn build<P: AsRef<Path>>(source: P, dest: P) -> Result<()> {
             fs::write(file, content).expect("Write file failed");
         });
     }
-    println!("Build cost: {}", instant.elapsed().as_micros());
+    println!("Build cost: {}ms", instant.elapsed().as_millis());
     Ok(())
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -50,7 +50,7 @@ fn init_tera(source: &Path, locale: &str) {
         #[cfg(debug_assertions)]
         return parking_lot::RwLock::new(tera);
         #[cfg(not(debug_assertions))]
-        return Arc::new(tera);
+        return std::sync::Arc::new(tera);
     });
     #[cfg(debug_assertions)]
     {
@@ -64,7 +64,7 @@ fn init_tera(source: &Path, locale: &str) {
 }
 
 #[cfg(not(debug_assertions))]
-fn get_tera() -> std::sync::Arc<Tera> {
+fn get_tera() -> &'static std::sync::Arc<Tera> {
     TERA.get().expect("Tera haven't initialized")
 }
 

--- a/src/entity/article.rs
+++ b/src/entity/article.rs
@@ -14,7 +14,7 @@ use crate::{
 
 use super::{EndMatter, Entity};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Article {
     pub file: String,
     /// The slug after this artcile rendered.

--- a/src/entity/end_matter.rs
+++ b/src/entity/end_matter.rs
@@ -11,13 +11,13 @@ use serde::{Deserialize, Serialize};
 /// content = "Have a good day!"
 /// +++
 /// ```
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EndMatter {
     #[serde(rename(deserialize = "comment"))]
     pub comments: Vec<Comment>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Comment {
     // The author name.
     // Plain text format.

--- a/src/entity/page.rs
+++ b/src/entity/page.rs
@@ -14,7 +14,7 @@ use crate::{
 
 use super::Entity;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Page {
     // The page's markdown content.
     pub markdown: String,

--- a/src/entity/season.rs
+++ b/src/entity/season.rs
@@ -104,7 +104,7 @@ impl Entity for Season {
 
             tokio::task::spawn_blocking(move || {
                 article
-                    .render(context.clone(), &dest)
+                    .render(context, &dest)
                     .expect("Render article failed.");
             });
         }


### PR DESCRIPTION
This PR aims to speed up parsing and rendering by using `rayon` and tokio spawn blocking task.

A simple build time cost comparation (microseconds):
## before:
- debug: 1242431, 1471965
- release: 17792, 19198

## after:
- debug: 1043317, 1113345
- release: 7912, 9150
