### PR TITLE
Rewrite html base url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ http-body = "0.4.4"
 hyper = { version = "0.14.17", features = ["client", "server", "tcp", "http1"] }
 hyper-tls = "0.5.0"
 intl-memoizer = "0.5.1"
+lol_html = "0.3.1"
 markup5ever_rcdom = "0.1.0"
 notify = "4.0.17"
 once_cell = "1.10.0"

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -5,12 +5,17 @@ use std::{
 
 use crate::{
     code_blocks::{render_code_block, ALL_CODE_BLOCKS},
+    current_mode,
     entity::{Entity, Zine},
+    helpers::rewrite_html_base_url,
     locales::FluentLoader,
+    Mode,
 };
 
 use anyhow::Result;
+use hyper::Uri;
 use once_cell::sync::OnceCell;
+use serde_json::Value;
 use tera::{Context, Tera};
 use tokio::{runtime::Handle, task};
 
@@ -92,6 +97,20 @@ impl Render {
         }
 
         get_tera().render_to(template, context, &mut buf)?;
+
+        if current_mode() == Some(Mode::Build) {
+            if let Some(Value::String(site_url)) =
+                context.get("site").and_then(|site| site.get("url"))
+            {
+                let uri = site_url.parse::<Uri>().expect("Invalid site url.");
+                if !uri.path().is_empty() {
+                    let html = rewrite_html_base_url(&buf, site_url)?;
+                    fs::write(dest, html)?;
+                    return Ok(());
+                }
+            }
+        }
+
         fs::write(dest, buf)?;
         Ok(())
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -98,11 +98,15 @@ impl Render {
 
         get_tera().render_to(template, context, &mut buf)?;
 
-        if current_mode() == Some(Mode::Build) {
+        // Rewrite root path links with site url if and only if:
+        // 1. in build run mode
+        // 2. site url has a path
+        if matches!(current_mode(), Some(Mode::Build)) {
             if let Some(Value::String(site_url)) =
                 context.get("site").and_then(|site| site.get("url"))
             {
                 let uri = site_url.parse::<Uri>().expect("Invalid site url.");
+                // We don't need to rewrite links if the site url is a naked domain without any path.
                 if !uri.path().is_empty() {
                     let html = rewrite_html_base_url(&buf, site_url)?;
                     fs::write(dest, html)?;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -213,11 +213,11 @@ mod tests {
     #[test_case("<a href=\"{}\"></a>", "/"; "a1")]
     #[test_case("<a href=\"{}\"></a>", "/hello"; "a2")]
     #[test_case("<a href=\"{}\"></a>", "/hello/world"; "a3")]
-    #[test_case("<link rel=\"stylesheet\" src=\"{}\"/>", "/hello.css"; "link")]
-    #[test_case("<img src=\"{}\"/>", "/hello.png"; "img")]
-    #[test_case("<script src=\"{}\"/>", "/hello.js"; "script")]
-    #[test_case("<audio src=\"{}\"/>", "/hello.mp3"; "audio")]
-    #[test_case("<video src=\"{}\"/>", "/hello.mp4"; "video")]
+    #[test_case("<link rel=\"stylesheet\" href=\"{}\" />", "/hello.css"; "link")]
+    #[test_case("<img src=\"{}\" />", "/hello.png"; "img")]
+    #[test_case("<script src=\"{}\" />", "/hello.js"; "script")]
+    #[test_case("<audio src=\"{}\" />", "/hello.mp3"; "audio")]
+    #[test_case("<video src=\"{}\" />", "/hello.mp4"; "video")]
     #[test_case("<iframe src=\"{}\"></iframe>", "/hello.html"; "iframe")]
     fn test_rewrite_html_base_url(html: &str, path: &str) {
         assert_eq!(
@@ -245,6 +245,22 @@ mod tests {
                     .unwrap()
             ),
             html.replace("{}", &whole_url)
+        );
+    }
+
+    #[test_case("<a href=\"{}\"></a>", "hello"; "a1")]
+    #[test_case("<link rel=\"stylesheet\" src=\"{}\"/>", "hello.css"; "link")]
+    #[test_case("<img src=\"{}\"/>", "hello.png"; "img")]
+    #[test_case("<script src=\"{}\"/>", "hello.js"; "script")]
+    #[test_case("<audio src=\"{}\"/>", "hello.mp3"; "audio")]
+    #[test_case("<video src=\"{}\"/>", "hello.mp4"; "video")]
+    #[test_case("<iframe src=\"{}\"></iframe>", "hello.html"; "iframe")]
+    fn test_not_rewrite_html_base_url_absolute_path(html: &str, path: &str) {
+        assert_eq!(
+            String::from_utf8_lossy(
+                &rewrite_html_base_url(html.replace("{}", &path).as_bytes(), BASE_URL).unwrap()
+            ),
+            html.replace("{}", &path)
         );
     }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -15,7 +15,8 @@ use markup5ever_rcdom::{Handle, NodeData, RcDom};
 
 use crate::meta::Meta;
 
-pub fn rewrite_html_base_url(raw: &[u8], base_url: &str) -> Result<Vec<u8>> {
+/// Rewrite root path URL in `raw_html` with `base_url`.
+pub fn rewrite_html_base_url(raw_html: &[u8], base_url: &str) -> Result<Vec<u8>> {
     let rewrite_url_in_attr = |el: &mut Element, attr_name: &str| {
         if let Some(attr) = el.get_attribute(attr_name) {
             if attr.starts_with('/') {
@@ -29,14 +30,17 @@ pub fn rewrite_html_base_url(raw: &[u8], base_url: &str) -> Result<Vec<u8>> {
     let mut html_rewriter = HtmlRewriter::new(
         Settings {
             element_content_handlers: vec![
-                element!("a[href]", |el| {
+                element!("a[href], link[rel=stylesheet][href]", |el| {
                     rewrite_url_in_attr(el, "href");
                     Ok(())
                 }),
-                element!("img[src]", |el| {
-                    rewrite_url_in_attr(el, "src");
-                    Ok(())
-                }),
+                element!(
+                    "script[src], iframe[src], img[src], audio[src], video[src]",
+                    |el| {
+                        rewrite_url_in_attr(el, "src");
+                        Ok(())
+                    }
+                ),
             ],
             ..Default::default()
         },
@@ -44,7 +48,7 @@ pub fn rewrite_html_base_url(raw: &[u8], base_url: &str) -> Result<Vec<u8>> {
             html.extend_from_slice(c);
         },
     );
-    html_rewriter.write(raw)?;
+    html_rewriter.write(raw_html)?;
 
     Ok(html)
 }
@@ -197,6 +201,52 @@ pub fn copy_dir(source: &Path, dest: &Path) -> Result<()> {
             anyhow::Ok(())
         })?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rewrite_html_base_url;
+    use test_case::test_case;
+
+    const BASE_URL: &str = "https://github.com";
+
+    #[test_case("<a href=\"{}\"></a>", "/"; "a1")]
+    #[test_case("<a href=\"{}\"></a>", "/hello"; "a2")]
+    #[test_case("<a href=\"{}\"></a>", "/hello/world"; "a3")]
+    #[test_case("<link rel=\"stylesheet\" src=\"{}\"/>", "/hello.css"; "link")]
+    #[test_case("<img src=\"{}\"/>", "/hello.png"; "img")]
+    #[test_case("<script src=\"{}\"/>", "/hello.js"; "script")]
+    #[test_case("<audio src=\"{}\"/>", "/hello.mp3"; "audio")]
+    #[test_case("<video src=\"{}\"/>", "/hello.mp4"; "video")]
+    #[test_case("<iframe src=\"{}\"></iframe>", "/hello.html"; "iframe")]
+    fn test_rewrite_html_base_url(html: &str, path: &str) {
+        assert_eq!(
+            String::from_utf8_lossy(
+                &rewrite_html_base_url(html.replace("{}", path).as_bytes(), BASE_URL).unwrap()
+            ),
+            html.replace("{}", &format!("{}{}", BASE_URL, path))
+        );
+    }
+
+    #[test_case("<a href=\"{}\"></a>", "/"; "a1")]
+    #[test_case("<a href=\"{}\"></a>", "/hello"; "a2")]
+    #[test_case("<a href=\"{}\"></a>", "/hello/world"; "a3")]
+    #[test_case("<link rel=\"stylesheet\" src=\"{}\"/>", "/hello.css"; "link")]
+    #[test_case("<img src=\"{}\"/>", "/hello.png"; "img")]
+    #[test_case("<script src=\"{}\"/>", "/hello.js"; "script")]
+    #[test_case("<audio src=\"{}\"/>", "/hello.mp3"; "audio")]
+    #[test_case("<video src=\"{}\"/>", "/hello.mp4"; "video")]
+    #[test_case("<iframe src=\"{}\"></iframe>", "/hello.html"; "iframe")]
+    fn test_not_rewrite_html_base_url(html: &str, path: &str) {
+        let whole_url = format!("{}{}", BASE_URL, path);
+        assert_eq!(
+            String::from_utf8_lossy(
+                &rewrite_html_base_url(html.replace("{}", &whole_url).as_bytes(), BASE_URL)
+                    .unwrap()
+            ),
+            html.replace("{}", &whole_url)
+        );
+    }
 }
 
 /// A serde module to serialize and deserialize [`time::Date`] type.

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,12 +30,13 @@ pub static TEMP_ZINE_BUILD_DIR: &str = "__zine_build";
 
 pub static MODE: Lazy<RwLock<Option<Mode>>> = Lazy::new(|| RwLock::new(None));
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone)]
 pub enum Mode {
     Build,
     Serve,
 }
 
+/// Get current run mode.
 pub fn current_mode() -> Option<Mode> {
     *MODE.read()
 }

--- a/templates/index.jinja
+++ b/templates/index.jinja
@@ -30,7 +30,7 @@
                     </div>
                 {% endfor %}
                 <div class="mt-8 sm:mx-2 flex w-full mx-auto ">
-                    <a href="{{ season.slug }}" class="p-3 px-12 mx-auto my-8 bg-primary text-main text-sm font-bold rounded transition sm:hover:scale-110 duration-500">
+                    <a href="/{{ season.slug }}" class="p-3 px-12 mx-auto my-8 bg-primary text-main text-sm font-bold rounded transition sm:hover:scale-110 duration-500">
                         {{ fluent(key = "view-more") }}
                     </a>
                 </div>


### PR DESCRIPTION
This PR is mainly to fix https://github.com/zineland/zine/issues/11. 

Instead of adding a `public_url`, we rewrite all root paths with the base URL 
if the base URL isn't a naked domain. For instance, if the `site_url` is a Github 
Pages URL, such as `https://zineland.github.io/zine`, the `/hello.css` link would
be rewritten to `https://zineland.github.io/zine/hello.css`. For naked domain URLs, 
we do nothing.

The benefit is we bring no extra concepts to the user, for example, the user 
doesn't need to learn what the `public_url` is, this keeps zine as simple and 
intuitive as possible.