### PR TITLE
Enhance zine initial project testings

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,5 +34,8 @@ jobs:
       run: |
         export PATH="$HOME/.cargo/bin:$PATH"
         cargo install --path .
-        cd demo
-        zine build
+        # Test build demo
+        cd demo; zine build
+        # Test new empty project then build
+        zine new test; cd test; zine build
+    


### PR DESCRIPTION
https://github.com/zineland/zine/pull/23 introduces a new bug #31. 
I think we should add a `zine` initial project CI testing to avoid it.