### PR TITLE
fix build error on apple silicon ship #43

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.aarch64-apple-darwin]
+linker = "/usr/bin/gcc"


### PR DESCRIPTION
fix for #43 
 
Configure a linker for aarch64-apple-darwin in order to build the project on m1 apple machine.