### PR TITLE
Support customize article extend template

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,24 +96,24 @@ menu = [
 # Declare authors of this magazine.
 [authors]
 # set editor to true will show the Editor badge on the author profile page
-zine-team = { name = "Zine Team", editor = true, bio = "The Zine Team." }
+zine_team = { name = "Zine Team", editor = true, bio = "The Zine Team." }
 
 # You can customize some theme elements in this section.
 # All of those elements are optional.
 [theme]
 # the primary color
-primary-color = "#abcdef"
-secondary-color = "#fff"
+primary_color = "#abcdef"
+secondary_color = "#fff"
 # the main text color
-main-color = "#000"
+main_color = "#000"
 # the link color in article content
-link-color = "#e07312"
+link_color = "#e07312"
 # the background image
-background-image = "/static/background.png"
+background_image = "/static/background.png"
 # you can customize your head here, such as your css, js.
-head-template = "templates/head.html"
+head_template = "templates/head.html"
 # you can customize your footer here
-footer-template = "templates/footer.html"
+footer_template = "templates/footer.html"
 
 # You can customize some markdown styles in this section.
 # All of those elements are optional.

--- a/README.md
+++ b/README.md
@@ -110,10 +110,12 @@ main_color = "#000"
 link_color = "#e07312"
 # the background image
 background_image = "/static/background.png"
-# you can customize your head here, such as your css, js.
+# you can customize your head here, such as your css, js
 head_template = "templates/head.html"
 # you can customize your footer here
 footer_template = "templates/footer.html"
+# you can extend the article page, for example adding comment widget
+article_extend_template = "templates/article-extend.html"
 
 # You can customize some markdown styles in this section.
 # All of those elements are optional.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -89,6 +89,10 @@ fn init_tera(source: &Path, zine: &Zine) {
         tera.add_raw_template("footer_template.jinja", footer_template)
             .expect("Cannot add footer_template");
     }
+    if let Some(article_extend_template) = zine.theme.article_extend_template.as_ref() {
+        tera.add_raw_template("article_extend_template.jinja", article_extend_template)
+            .expect("Cannot add article_extend_template");
+    }
 
     // Dynamically register functions that need dynamic configuration.
     tera.register_function(

--- a/src/entity/theme.rs
+++ b/src/entity/theme.rs
@@ -27,6 +27,9 @@ pub struct Theme {
     pub head_template: Option<String>,
     // The custom footer template path, will be parsed to html.
     pub footer_template: Option<String>,
+    // The extend template path for article page, will be parsed to html.
+    // Normally, this template can be a comment widget, such as https://giscus.app.
+    pub article_extend_template: Option<String>,
 }
 
 impl Default for Theme {
@@ -39,6 +42,7 @@ impl Default for Theme {
             background_image: None,
             head_template: None,
             footer_template: None,
+            article_extend_template: None,
         }
     }
 }
@@ -53,6 +57,10 @@ impl std::fmt::Debug for Theme {
             .field("background_image", &self.background_image)
             .field("head_template", &self.head_template.is_some())
             .field("footer_template", &self.footer_template.is_some())
+            .field(
+                "article_extend_template",
+                &self.article_extend_template.is_some(),
+            )
             .finish()
     }
 }
@@ -100,6 +108,17 @@ impl Entity for Theme {
                     format!(
                         "Failed to parse the footer template: `{}`",
                         source.join(footer_template).display(),
+                    )
+                })?,
+            );
+        }
+        if let Some(article_extend_template) = self.article_extend_template.as_ref() {
+            // Read article extend template from path to html.
+            self.article_extend_template = Some(
+                fs::read_to_string(source.join(&article_extend_template)).with_context(|| {
+                    format!(
+                        "Failed to parse the article extend template: `{}`",
+                        source.join(article_extend_template).display(),
                     )
                 })?,
             );

--- a/templates/article.jinja
+++ b/templates/article.jinja
@@ -65,4 +65,7 @@
             </div>
         {% endif -%}
     </div>
+    {% if theme.article_extend_template -%}
+        {% include "article_extend_template.jinja" -%}
+    {% endif -%}
 {% endblock content -%}


### PR DESCRIPTION
Add `article_extend_template` to help user customize their comment widget, for example:
```html
<div class="mx-4">
    <div class="giscus"></div>
</div>
<script src="https://giscus.app/client.js"
    data-repo="zineland/2d2d"
    data-repo-id="R_kgDOG8KMPw"
    data-category="Announcements"
    data-category-id="DIC_kwDOG8KMP84CPN6h"
    data-mapping="pathname"
    data-reactions-enabled="1"
    data-emit-metadata="0"
    data-input-position="top"
    data-theme="light"
    data-lang="en"
    data-loading="lazy"
    crossorigin="anonymous"
    async>
</script>
```
<img width="1040" alt="image" src="https://user-images.githubusercontent.com/3369694/169646222-6e23c6a0-69b3-4023-9d95-47f613beab04.png">
