### PR TITLE
Fix markdown visitor not fallback to origin tag

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -10,7 +10,7 @@ use crate::{
     entity::{Entity, MarkdownConfig, Zine},
     html::rewrite_html_base_url,
     locales::FluentLoader,
-    markdown::{markdown_to_html, MarkdownVistor},
+    markdown::{markdown_to_html, MarkdownVisitor},
     Mode,
 };
 
@@ -259,11 +259,11 @@ impl<'a> Vistor<'a> {
     }
 }
 
-impl<'a, 'b: 'a> MarkdownVistor<'b> for Vistor<'a> {
-    fn visit_start_tag(&mut self, tag: Tag<'b>) -> Option<Event<'static>> {
+impl<'a, 'b: 'a> MarkdownVisitor<'b> for Vistor<'a> {
+    fn visit_start_tag(&mut self, tag: &Tag<'b>) -> Option<Event<'static>> {
         match tag {
             Tag::CodeBlock(CodeBlockKind::Fenced(name)) => {
-                self.code_block_fenced = Some(name);
+                self.code_block_fenced = Some(name.clone());
             }
             Tag::Image(_, src, title) => {
                 // Add loading="lazy" attribute for markdown image.
@@ -273,12 +273,12 @@ impl<'a, 'b: 'a> MarkdownVistor<'b> for Vistor<'a> {
             }
             Tag::Heading(level, id, _) => {
                 self.heading_ref = Some(HeadingRef {
-                    level: level as usize,
+                    level: *level as usize,
                     // This id is parsed from the markdow heading part.
                     // Here is the syntax:
                     // `# Long title {#title}` parse the id: title
                     // See https://docs.rs/pulldown-cmark/latest/pulldown_cmark/struct.Options.html#associatedconstant.ENABLE_HEADING_ATTRIBUTES
-                    id,
+                    id: *id,
                 });
             }
             _ => {}
@@ -286,7 +286,7 @@ impl<'a, 'b: 'a> MarkdownVistor<'b> for Vistor<'a> {
         None
     }
 
-    fn visit_end_tag(&mut self, tag: Tag<'_>) -> Option<Event<'static>> {
+    fn visit_end_tag(&mut self, tag: &Tag<'_>) -> Option<Event<'static>> {
         match tag {
             Tag::CodeBlock(_) => {
                 self.code_block_fenced = None;

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -1,23 +1,27 @@
 use pulldown_cmark::Event::{self, Code, End, HardBreak, Rule, SoftBreak, Start, Text};
 use pulldown_cmark::{html, CowStr, Options, Parser, Tag};
 
-pub trait MarkdownVistor<'a> {
-    fn visit_start_tag(&mut self, tag: Tag<'a>) -> Option<Event<'static>>;
-    fn visit_end_tag(&mut self, tag: Tag<'a>) -> Option<Event<'static>>;
+/// The visitor trait to allow customize html rendering.
+///
+/// All methods return a `Option<Event>>`, custom html event will
+/// be rendered if `Some()` returned, otherwise, will fallback to the original event.
+pub trait MarkdownVisitor<'a> {
+    fn visit_start_tag(&mut self, tag: &Tag<'a>) -> Option<Event<'static>>;
+    fn visit_end_tag(&mut self, tag: &Tag<'a>) -> Option<Event<'static>>;
     fn visit_text(&mut self, text: &CowStr<'a>) -> Option<Event<'static>>;
     fn visit_code(&mut self, code: &CowStr<'a>) -> Option<Event<'static>>;
 }
 
 /// Render markdown to HTML.
-pub fn markdown_to_html<'a>(markdown: &'a str, mut visitor: impl MarkdownVistor<'a>) -> String {
+pub fn markdown_to_html<'a>(markdown: &'a str, mut v: impl MarkdownVisitor<'a>) -> String {
     let parser_events_iter = Parser::new_ext(markdown, Options::all()).into_offset_iter();
     let events = parser_events_iter
         .into_iter()
         .filter_map(|(event, _)| match event {
-            Event::Start(tag) => visitor.visit_start_tag(tag),
-            Event::End(tag) => visitor.visit_end_tag(tag),
-            Event::Code(code) => visitor.visit_code(&code).or(Some(Event::Code(code))),
-            Event::Text(text) => visitor
+            Event::Start(tag) => v.visit_start_tag(&tag).or(Some(Event::Start(tag))),
+            Event::End(tag) => v.visit_end_tag(&tag).or(Some(Event::End(tag))),
+            Event::Code(code) => v.visit_code(&code).or(Some(Event::Code(code))),
+            Event::Text(text) => v
                 .visit_text(&text)
                 // Not a code block inside text, or the code block's fenced is unsupported.
                 // We still need record this text event.


### PR DESCRIPTION
We should fall back to the original tag if the downstream return no custom `Event`.

```diff
Event::Start(tag) => v.visit_start_tag(&tag)
+  .or(Some(Event::Start(tag))),
Event::End(tag) => v.visit_end_tag(&tag)
+. .or(Some(Event::End(tag))),
```