### PR TITLE
Improve error recovery when serving

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -47,7 +47,11 @@ pub async fn watch_build<P: AsRef<Path>>(source: P, dest: P, watch: bool) -> Res
 
             loop {
                 match rx.recv() {
-                    Ok(_) => build(&mut engine, true)?,
+                    Ok(_) => {
+                        if let Err(err) = build(&mut engine, true) {
+                            println!("build error: {:?}", &err);
+                        }
+                    }
                     Err(err) => println!("watch error: {:?}", &err),
                 }
             }


### PR DESCRIPTION
When a build error occured, the `watch_build` function would exit its watching loop and exit on error.

Instead, this PR makes it print the error, and continue to be able to recover.

This is a partial correction of #126 , the `panic!` call on date formatting still let the `serve` in a bad state