### PR TITLE
Feat: Add a way to create a new issue by chaining

### DIFF
--- a/src/entity/issue.rs
+++ b/src/entity/issue.rs
@@ -11,7 +11,7 @@ use super::{article::Article, Entity};
 
 /// The issue entity config.
 /// It parsed from issue directory's `zine.toml`.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, Default)]
 pub struct Issue {
     /// The slug after this issue rendered.
     /// Fallback to issue path name if no slug specified.
@@ -49,6 +49,26 @@ impl std::fmt::Debug for Issue {
 }
 
 impl Issue {
+    fn new() -> Self {
+        Self {
+            ..Default::default()
+
+
+        }
+    }
+    fn set_issue_number(&mut self, number: u32) -> &mut Self {
+        self.number = number;
+        self
+    }
+    fn set_title(&mut self, title: impl Into<String>) -> &mut Self {
+        self.title = title.into();
+        self.dir = self.title.clone().to_lowercase().replace(" ", "-");
+        self
+    }
+    fn set_intro(&mut self, intro: impl Into<String>) -> &mut Self {
+        self.intro = Some(intro.into());
+        self
+    }
     // Get the description of this issue.
     // Mainly for html meta description tag.
     fn description(&self) -> String {
@@ -141,5 +161,21 @@ impl Entity for Issue {
         context.insert("intro", &self.intro);
         engine::render("issue.jinja", &context, issue_dir)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::entity::issue::Issue;
+
+    #[test]
+    fn defaults() {
+
+        let mut issue = Issue::new();
+        issue.set_issue_number(1)
+              .set_title("Some Magical Title")
+              .set_intro("Some magical introduction to some amazing Issue");
+        println!("{:?}", issue);
     }
 }

--- a/src/entity/issue.rs
+++ b/src/entity/issue.rs
@@ -1,9 +1,5 @@
 use std::io::prelude::*;
-use std::{
-    borrow::Cow,
-    fs,
-    path::{Path, PathBuf},
-};
+use std::{borrow::Cow, fs, path::Path};
 
 use crate::ZINE_FILE;
 
@@ -67,7 +63,7 @@ impl Issue {
     }
     fn set_title(&mut self, title: impl Into<String>) -> &mut Self {
         self.title = title.into();
-        self.dir = self.title.clone().to_lowercase().replace(" ", "-");
+        self.dir = self.title.clone().to_lowercase().replace(' ', "-");
         self.slug = self.dir.clone();
         self
     }
@@ -76,18 +72,18 @@ impl Issue {
         self
     }
     // Appends the issue to the top level zine.toml file
-    fn write_new_issue(&self, path: &PathBuf) -> Result<()> {
+    fn write_new_issue(&self, path: &Path) -> Result<()> {
         if path.join(ZINE_FILE).exists() {
             Err(anyhow::anyhow!("Issue already Exists"))?
         }
         let mut file = std::fs::OpenOptions::new()
             .append(true)
             .create(true)
-            .open(&path.join(ZINE_FILE))?;
+            .open(path.join(ZINE_FILE))?;
 
         let toml_str = toml::to_string(&self)?;
 
-        file.write_all(&toml_str.as_bytes())?;
+        file.write_all(toml_str.as_bytes())?;
 
         Ok(())
     }

--- a/src/entity/issue.rs
+++ b/src/entity/issue.rs
@@ -174,8 +174,8 @@ mod tests {
 
         let mut issue = Issue::new();
         issue.set_issue_number(1)
-              .set_title("Some Magical Title")
-              .set_intro("Some magical introduction to some amazing Issue");
+             .set_title("Some Magical Title")
+             .set_intro("Some magical introduction to some amazing Issue");
         println!("{:?}", issue);
     }
 }


### PR DESCRIPTION
This is an example of how Site, Issue, Article and other stuctures might
be better managed. This would remove the need for some `Scaffolding` as
well as keep the struct data in one place. This would help avoid
duplication.
