### PR TITLE
Refactor how Site struct is created

### DIFF
--- a/src/entity/site.rs
+++ b/src/entity/site.rs
@@ -1,9 +1,9 @@
-use std::{env, path::PathBuf};
-use std::io::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::io::prelude::*;
+use std::{env, path::PathBuf};
 use toml;
 
-use anyhow::{Result};
+use anyhow::Result;
 
 use crate::ZINE_FILE;
 
@@ -18,7 +18,6 @@ struct SiteBuilder {
 impl SiteBuilder {
     // Defines a new site with default settings while providing a new an optional site `name`
     fn new(name: Option<String>) -> std::result::Result<Self, anyhow::Error> {
-
         let source = if let Some(name) = name.as_ref() {
             env::current_dir()?.join(name)
         } else {
@@ -36,7 +35,6 @@ impl SiteBuilder {
         })
     }
     fn create_new_zine_dir(&self) -> std::result::Result<PathBuf, anyhow::Error> {
-
         if !self.source.exists() {
             std::fs::create_dir_all(&self.source)?
         }
@@ -52,7 +50,6 @@ mod site_builder {
 
     #[test]
     fn site_to_build() {
-
         let work_space = std::path::Path::new("/tmp");
         assert!(env::set_current_dir(&work_space).is_ok());
 
@@ -62,21 +59,18 @@ mod site_builder {
         assert_eq!(site.author, "");
         assert_eq!(site.site.url, "http://localhost");
         assert!(site.create_new_zine_dir().is_ok());
-        assert!(site.site.write_toml(site.source).is_ok());
-
+        assert!(site.site.write_toml(&site.source).is_ok());
     }
 
     #[test]
     fn test_site_builder_new() {
-
         let new_site = SiteBuilder::new(Some("test".to_string()));
 
         if let Ok(new_site) = new_site {
             assert_eq!(new_site.name, Some("test".to_string()));
             assert_eq!(new_site.site.name, "test".to_string());
             assert!(new_site.create_new_zine_dir().is_ok());
-            assert!(new_site.site.write_toml(new_site.source).is_ok());
-
+            assert!(new_site.site.write_toml(&new_site.source).is_ok());
         }
     }
 }
@@ -117,12 +111,10 @@ impl Default for Site {
 }
 
 impl Site {
-
-    fn write_toml(&self, path: PathBuf) -> Result<()>{
-
+    fn write_toml(&self, path: &PathBuf) -> Result<()> {
         let mut file = std::fs::OpenOptions::new()
-            .append(true)
-            .create(true)
+            .write(true)
+            .create_new(true)
             .open(&path.join(ZINE_FILE))?;
 
         let toml_str = toml::to_string(&self)?;
@@ -131,7 +123,6 @@ impl Site {
 
         Ok(())
     }
-    
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/entity/site.rs
+++ b/src/entity/site.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::io::prelude::*;
-use std::{env, path::PathBuf};
+use std::{env, path::{Path, PathBuf}};
 use toml;
 
 use anyhow::Result;
@@ -111,15 +111,15 @@ impl Default for Site {
 }
 
 impl Site {
-    fn write_toml(&self, path: &PathBuf) -> Result<()> {
+    fn write_toml(&self, path: &Path) -> Result<()> {
         let mut file = std::fs::OpenOptions::new()
             .write(true)
             .create_new(true)
-            .open(&path.join(ZINE_FILE))?;
+            .open(path.join(ZINE_FILE))?;
 
         let toml_str = toml::to_string(&self)?;
 
-        file.write_all(&toml_str.as_bytes())?;
+        file.write_all(toml_str.as_bytes())?;
 
         Ok(())
     }

--- a/src/entity/site.rs
+++ b/src/entity/site.rs
@@ -17,7 +17,7 @@ struct SiteBuilder {
 
 impl SiteBuilder {
     // Defines a new site with default settings while providing a new an optional site `name`
-    fn new(name: Option<String>) -> std::result::Result<Self, anyhow::Error> {
+    fn new(name: Option<String>) -> Result<Self> {
         let source = if let Some(name) = name.as_ref() {
             env::current_dir()?.join(name)
         } else {
@@ -34,7 +34,7 @@ impl SiteBuilder {
             ..Default::default()
         })
     }
-    fn create_new_zine_dir(&self) -> std::result::Result<PathBuf, anyhow::Error> {
+    fn create_new_zine_dir(&self) -> Result<PathBuf> {
         if !self.source.exists() {
             std::fs::create_dir_all(&self.source)?
         }


### PR DESCRIPTION
Refactor struct Site

I am looking through the code to learn how this works.
I noticed there seems to be some code duplication. This is clear when looking at how `new.rs` has been done.

I think it would be cleaner if each struct takes care of many of their own needs. This would remove the need for `new.rs` to directly know how `Site`, `Issue` and others are defined.

This would make `new.rs` much cleaner and the code much easier to manage and maintain in the future.

This will take some time work through but would possibly make a good learning case.
Here is some of the work that I have done on `struct Site` by introducing `struct SiteBuilder`

Thoughts?
