### PR TITLE
Refactor new commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,4 +52,5 @@ walkdir = "2"
 
 [dev-dependencies]
 anyhow = { version = "1.0", features = ["backtrace"] }
+tempfile = "3"
 test-case = "2"

--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,7 @@ fn main() {
     let build_info: String =
         from_git().unwrap_or_else(|_| "Build info from Git not present".into());
 
-    println!("cargo:rustc-env=BUILD_INFO={}", build_info);
+    println!("cargo:rustc-env=BUILD_INFO={build_info}");
 }
 
 fn run(args: &[&str]) -> Result<String, std::io::Error> {
@@ -20,11 +20,11 @@ fn run(args: &[&str]) -> Result<String, std::io::Error> {
 fn from_git() -> Result<String, std::io::Error> {
     // Read the current git commit hash
     let rev = run(&["git", "rev-parse", "--verify", "--short", "HEAD"])?;
-    println!("cargo:rustc-env=GIT_REV={}", rev);
+    println!("cargo:rustc-env=GIT_REV={rev}");
 
     // Read the current branch name.
     let branch = run(&["git", "rev-parse", "--abbrev-ref", "HEAD"])?;
-    println!("cargo:rustc-env=GIT_BRANCH={}", branch);
+    println!("cargo:rustc-env=GIT_BRANCH={branch}");
 
     // Read date from current build branch.
     // Here is a example output:
@@ -36,7 +36,6 @@ fn from_git() -> Result<String, std::io::Error> {
 
     // Combined
     Ok(format!(
-        "build branch in \"{}\", last commit id: {}",
-        branch, rev
+        "build branch in \"{branch}\", last commit id: {rev}"
     ))
 }

--- a/src/code_blocks/author.rs
+++ b/src/code_blocks/author.rs
@@ -24,8 +24,7 @@ impl<'a> CodeBlock for AuthorCode<'a> {
         if let Some(avatar) = author.avatar.as_ref() {
             writeln!(
                 &mut html,
-                r#"<img src="{}" alt="avatar" loading="lazy">"#,
-                avatar,
+                r#"<img src="{avatar}" alt="avatar" loading="lazy">"#,
             )?;
         }
         writeln!(

--- a/src/code_blocks/callout.rs
+++ b/src/code_blocks/callout.rs
@@ -63,11 +63,11 @@ impl<'a> CodeBlock for CalloutBlock<'a> {
             "background-color: {}; border-color: {}",
             self.bg_color, self.border_color,
         );
-        writeln!(&mut html, r#"<div class="callout" style="{}">"#, style)?;
+        writeln!(&mut html, r#"<div class="callout" style="{style}">"#)?;
         let zine_data = data::read();
         let markdown_config = zine_data.get_markdown_config();
         let block_html = MarkdownRender::new(markdown_config).render_html(self.content);
-        writeln!(&mut html, r#" <div>{}</div>"#, block_html)?;
+        writeln!(&mut html, r#" <div>{block_html}</div>"#)?;
         writeln!(&mut html, r#"</div>"#)?;
         Ok(html)
     }

--- a/src/code_blocks/mod.rs
+++ b/src/code_blocks/mod.rs
@@ -114,7 +114,7 @@ impl<'a> Fenced<'a> {
                                 Some((key.trim().replace('-', "_"), value.trim()))
                             }
                             _ => {
-                                println!("Warning: invalid fenced options: {}", pair);
+                                println!("Warning: invalid fenced options: {pair}");
                                 None
                             }
                         }

--- a/src/code_blocks/url_preview.rs
+++ b/src/code_blocks/url_preview.rs
@@ -39,7 +39,7 @@ impl<'a> CodeBlock for UrlPreviewBlock<'a> {
         writeln!(&mut html, r#" <a href="{url}">{url}</a>"#, url = self.url)?;
         if self.show_image {
             if let Some(image) = self.info.image.as_ref().filter(|i| !i.is_empty()) {
-                writeln!(&mut html, r#" <img src="{}" />"#, image)?;
+                writeln!(&mut html, r#" <img src="{image}" />"#)?;
             }
         }
         writeln!(&mut html, r#"</div>"#)?;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -199,7 +199,7 @@ impl ZineEngine {
 
         // Copy builtin static files into dest static dir.
         let dest_static_dir = self.dest.join("static");
-        fs::create_dir_all(&dest_static_dir)?;
+        fs::create_dir_all(dest_static_dir)?;
 
         #[cfg(not(debug_assertions))]
         include_dir::include_dir!("static").extract(dest_static_dir)?;

--- a/src/entity/article.rs
+++ b/src/entity/article.rs
@@ -5,6 +5,7 @@ use anyhow::{ensure, Context as _, Result};
 use serde::{Deserialize, Serialize};
 use tera::Context;
 use time::Date;
+use crate::helpers::get_date_of_today;
 
 use crate::{
     current_mode, data, engine,
@@ -97,7 +98,7 @@ impl Default for MetaArticle {
             path: None,
             author: None,
             cover: None,
-            pub_date: Date::MIN,
+            pub_date: get_date_of_today(),
         }
     }
 }
@@ -106,23 +107,23 @@ impl Default for MetaArticle {
 mod meta_article_tests {
 
     use crate::entity::{article::MetaArticle, author::AuthorId};
-    use time::Date;
+    use crate::helpers::get_date_of_today;
 
     #[test]
     fn test_meta_article_default() {
         let meta_defaults = MetaArticle::default();
 
-        assert_eq!(meta_defaults.file, "Give-this-file-a-name");
+        assert_eq!(meta_defaults.file, "give-this-file-a-name.md");
         assert_eq!(meta_defaults.slug, "1");
         assert_eq!(meta_defaults.path, None);
         assert_eq!(meta_defaults.title, "Give me a Title.");
         assert_eq!(meta_defaults.cover, None);
-        assert_eq!(meta_defaults.pub_date, Date::MIN);
+        assert_eq!(meta_defaults.pub_date, get_date_of_today());
     }
     #[test]
     fn test_meta_article_new() {
         let mut m_a = MetaArticle::new();
-        assert_eq!(m_a.file, "Give-this-file-a-name");
+        assert_eq!(m_a.file, "give-this-file-a-name.md");
         m_a.set_title("This is a test");
         assert_eq!(m_a.title, "This is a test");
         assert_eq!(m_a.file, "this-is-a-test");
@@ -404,10 +405,10 @@ mod tests_article_impl {
             toml_str.push_str("[[article]]\n");
             toml_str.push_str(toml::to_string::<Article>(&article).unwrap().as_str());
         }
-        
+
         let issue_from_toml: Issue = toml::from_str(&toml_str).unwrap();
         assert_eq!(issue.slug, issue_from_toml.slug);
-        assert_eq!(issue.articles[0].meta.file, "Give-this-file-a-name");
+        assert_eq!(issue.articles[0].meta.file, "give-this-file-a-name.md");
         assert_eq!(
             issue.articles[0].meta.file,
             issue_from_toml.articles[0].meta.file

--- a/src/entity/article.rs
+++ b/src/entity/article.rs
@@ -1,11 +1,11 @@
 use std::io::prelude::*;
 use std::{borrow::Cow, collections::HashMap, fs, path::Path};
 
+use crate::helpers::get_date_of_today;
 use anyhow::{ensure, Context as _, Result};
 use serde::{Deserialize, Serialize};
 use tera::Context;
 use time::Date;
-use crate::helpers::get_date_of_today;
 
 use crate::{
     current_mode, data, engine,
@@ -41,19 +41,20 @@ pub struct MetaArticle {
 
 impl MetaArticle {
     /// Create a new MetaAtricle using Defaults::defaults()
+    #[allow(dead_code)]
     fn new() -> Self {
         Self {
             ..Default::default()
         }
     }
     /// Set the Title for the article and also set the file based on the Title.
-    fn set_title(&mut self, title: &str) -> &mut Self {
+    pub(crate) fn set_title(&mut self, title: &str) -> &mut Self {
         self.title = title.into();
         self.file = self.title.clone().to_lowercase().replace(' ', "-");
         self
     }
     /// Set the Author Ids by parsing a provided string. Names should be simply listed with spaces
-    fn set_authors(&mut self, authors: &str) -> Result<&mut Self> {
+    pub(crate) fn set_authors(&mut self, authors: &str) -> Result<&mut Self> {
         if let Ok(authors) = authors.to_string().parse::<AuthorId>() {
             self.author = Some(authors);
             return Ok(self);
@@ -73,6 +74,7 @@ impl MetaArticle {
         Date::MIN
     }
 
+    // This should be removable as default date will always be the current date.
     fn is_default_pub_date(&self) -> bool {
         self.pub_date == Date::MIN
     }
@@ -161,6 +163,7 @@ pub struct Article {
 }
 
 impl Article {
+    #[allow(dead_code)]
     fn new() -> Self {
         Self {
             ..Default::default()
@@ -168,27 +171,32 @@ impl Article {
     }
     /// If you call set_meta. You do not need to call set_title as MetaArticle
     /// contains all the related details.
+    #[allow(dead_code)]
     fn set_meta(&mut self, article_meta: MetaArticle) -> &mut Self {
         self.meta = article_meta;
         self
     }
-    fn set_title(&mut self, title: &str) -> &mut Self {
+    #[allow(dead_code)]
+    pub(crate) fn set_title(&mut self, title: &str) -> &mut Self {
         self.meta.set_title(title);
         self
     }
-    fn set_featured_to_true(&mut self) -> &mut Self {
+    #[allow(dead_code)]
+    pub(crate) fn set_featured_to_true(&mut self) -> &mut Self {
         self.featured = true;
         self
     }
-    fn set_published_to_true(&mut self) -> &mut Self {
+    #[allow(dead_code)]
+    pub(crate) fn set_published_to_true(&mut self) -> &mut Self {
         self.publish = true;
         self
     }
-    fn set_canonical(&mut self, canonical: &str) -> &mut Self {
+    #[allow(dead_code)]
+    pub(crate) fn set_canonical(&mut self, canonical: &str) -> &mut Self {
         self.canonical = Some(canonical.into());
         self
     }
-    fn finalize(&self) -> Self {
+    pub(crate) fn finalize(&self) -> Self {
         self.to_owned()
     }
     pub(crate) fn append_article_to_toml(&self, path: &Path) -> Result<()> {

--- a/src/entity/article.rs
+++ b/src/entity/article.rs
@@ -61,7 +61,11 @@ impl MetaArticle {
             "Unable to parse string containing author names."
         ))
     }
-    fn finalize(&self) -> Self {
+    fn fix_file_name(&self) -> String {
+        std::format!("{}.md", self.title.clone().to_lowercase().replace(' ', "-"))
+    }
+    pub(crate) fn finalize(&mut self) -> Self {
+        self.path = Some(std::format!("/{}", self.fix_file_name()));
         self.to_owned()
     }
     fn default_pub_date() -> Date {
@@ -86,7 +90,7 @@ impl std::fmt::Debug for Article {
 impl Default for MetaArticle {
     fn default() -> Self {
         Self {
-            file: "Give-this-file-a-name".into(),
+            file: "give-this-file-a-name.md".into(),
             // Need more information on what this should be
             slug: "1".into(),
             title: "Give me a Title.".into(),

--- a/src/entity/article.rs
+++ b/src/entity/article.rs
@@ -214,7 +214,7 @@ impl Article {
             Err(anyhow::anyhow!("Issue toml file does not already exists"))?
         };
 
-        let mut file = std::fs::OpenOptions::new().append(true).open(&path)?;
+        let mut file = std::fs::OpenOptions::new().append(true).open(path)?;
 
         let toml_str = toml::to_string(&self)?;
 
@@ -451,8 +451,7 @@ impl Entity for Article {
             self.topics.iter().for_each(|topic| {
                 if !zine_data.is_valid_topic(topic) {
                     println!(
-                        "Warning: the topic `{}` is invalid, please declare it in the root `zine.toml`",
-                        topic
+                        "Warning: the topic `{topic}` is invalid, please declare it in the root `zine.toml`"
                     )
                 }
             });

--- a/src/entity/article.rs
+++ b/src/entity/article.rs
@@ -40,7 +40,7 @@ pub struct MetaArticle {
 }
 
 impl MetaArticle {
-    /// Create a new MetaAtricle using Defaults::defaults()
+    /// Create a new MetaAtricle using defaults()
     #[allow(dead_code)]
     fn new() -> Self {
         Self {
@@ -66,6 +66,8 @@ impl MetaArticle {
     fn fix_file_name(&self) -> String {
         std::format!("{}.md", self.title.clone().to_lowercase().replace(' ', "-"))
     }
+    /// This Return a validated fully formed MetaArticle Struct setting any needed fields
+    /// The name might want to be changed to build even though its not really a build strategy
     pub(crate) fn finalize(&mut self) -> Self {
         self.path = Some(std::format!("/{}", self.fix_file_name()));
         self.to_owned()
@@ -156,13 +158,14 @@ pub struct Article {
     #[serde(default)]
     pub publish: bool,
     /// The canonical link of this article.
-    /// See issue: https://github.com/zineland/zine/issues/141
+    /// See issue: <https://github.com/zineland/zine/issues/141>
     pub canonical: Option<String>,
     #[serde(default, skip_serializing)]
     pub i18n: HashMap<String, Article>,
 }
 
 impl Article {
+    /// Creates a new Article struct with default values.
     #[allow(dead_code)]
     fn new() -> Self {
         Self {
@@ -176,29 +179,35 @@ impl Article {
         self.meta = article_meta;
         self
     }
+    /// Set the title of the article.
     #[allow(dead_code)]
     pub(crate) fn set_title(&mut self, title: &str) -> &mut Self {
         self.meta.set_title(title);
         self
     }
+    /// Set the Article as featured to `true`
     #[allow(dead_code)]
     pub(crate) fn set_featured_to_true(&mut self) -> &mut Self {
         self.featured = true;
         self
     }
+    /// Set the Article as published to `true`
     #[allow(dead_code)]
     pub(crate) fn set_published_to_true(&mut self) -> &mut Self {
         self.publish = true;
         self
     }
+    /// Set the Canonocal URL for the article
     #[allow(dead_code)]
     pub(crate) fn set_canonical(&mut self, canonical: &str) -> &mut Self {
         self.canonical = Some(canonical.into());
         self
     }
+    /// Return a validated Article Struct. Note: Tests still needed
     pub(crate) fn finalize(&self) -> Self {
         self.to_owned()
     }
+    /// Write the TOML data for the article to the end of the `issue` TOML file
     pub(crate) fn append_article_to_toml(&self, path: &Path) -> Result<()> {
         // Article zine.toml file must exist
         if !path.exists() {

--- a/src/entity/author.rs
+++ b/src/entity/author.rs
@@ -48,7 +48,7 @@ impl AuthorId {
 }
 
 /// The author of an article. Declared in the root `zine.toml`'s **[authors]** table.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Author {
     /// The author id, which is the key declared in `[authors]` table.
     #[serde(skip_deserializing, default)]
@@ -65,6 +65,45 @@ pub struct Author {
     pub is_editor: bool,
 }
 
+impl std::fmt::Display for Author {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} = {{ name = \"{}\", editor = {}, bio = \"\"\"\n{}\n\"\"\" }}",
+            self.id,
+            match &self.name {
+                Some(name) => name,
+                None => "",
+            },
+            match self.is_editor {
+                true => "true",
+                false => "false",
+            },
+            // This should probably stay at the end of the file for now
+            match &self.bio {
+                Some(data) => data,
+                None => "",
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod author_tests {
+    use crate::Author;
+
+    #[test]
+    fn author() {
+        let author = Author {
+            id: "bob".into(),
+            name: Some("Bob".into()),
+            avatar: None,
+            bio: None,
+            is_editor: false,
+        };
+        println!("{}", author.to_string())
+    }
+}
 impl Entity for Author {
     fn parse(&mut self, _source: &Path) -> anyhow::Result<()> {
         // Fallback to default zine avatar if neccessary.

--- a/src/entity/author.rs
+++ b/src/entity/author.rs
@@ -22,8 +22,8 @@ impl std::str::FromStr for AuthorId {
     /// Note: Addtional checks should be added for sanity
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let mut author_id_vec = vec![];
-        if s.contains(" ") {
-            let s_inter = s.split_whitespace().into_iter();
+        if s.contains(' ') {
+            let s_inter = s.split_whitespace();
 
             for author_id in s_inter {
                 // Removed character checking. This needs to be reconsidered

--- a/src/entity/author.rs
+++ b/src/entity/author.rs
@@ -36,6 +36,17 @@ impl std::str::FromStr for AuthorId {
     }
 }
 
+impl AuthorId {
+    pub fn is_author(&self, id: &str) -> bool {
+        match self {
+            Self::One(author_id) => author_id.eq_ignore_ascii_case(id),
+            Self::List(authors) => authors
+                .iter()
+                .any(|author_id| author_id.eq_ignore_ascii_case(id)),
+        }
+    }
+}
+
 /// The author of an article. Declared in the root `zine.toml`'s **[authors]** table.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Author {
@@ -52,17 +63,6 @@ pub struct Author {
     #[serde(default)]
     #[serde(rename(deserialize = "editor"))]
     pub is_editor: bool,
-}
-
-impl AuthorId {
-    pub fn is_author(&self, id: &str) -> bool {
-        match self {
-            Self::One(author_id) => author_id.eq_ignore_ascii_case(id),
-            Self::List(authors) => authors
-                .iter()
-                .any(|author_id| author_id.eq_ignore_ascii_case(id)),
-        }
-    }
 }
 
 impl Entity for Author {

--- a/src/entity/author.rs
+++ b/src/entity/author.rs
@@ -15,7 +15,8 @@ pub enum AuthorId {
     // Co-authors.
     List(Vec<String>),
 }
-
+/// Provides a parser to create AuthorId Structs
+/// Strings should be in the form of a space delimited list of names
 impl std::str::FromStr for AuthorId {
     type Err = ZineError;
     /// Creates a AuthorId Struct from string imput. The string should be `space` delimited
@@ -47,7 +48,7 @@ impl AuthorId {
     }
 }
 
-/// The author of an article. Declared in the root `zine.toml`'s **[authors]** table.
+/// The author of an article. Declared in the root `zine.toml`'s **\[authors\]** table.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Author {
     /// The author id, which is the key declared in `[authors]` table.
@@ -64,7 +65,7 @@ pub struct Author {
     #[serde(rename(deserialize = "editor"))]
     pub is_editor: bool,
 }
-
+/// Implementation for Display. Will return a JSON style string for writing to the `Site` TOML file.
 impl std::fmt::Display for Author {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(

--- a/src/entity/issue.rs
+++ b/src/entity/issue.rs
@@ -118,9 +118,9 @@ impl Issue {
         let mut md_file = std::fs::OpenOptions::new()
             .create_new(true)
             .write(true)
-            .open(&path.join(&self.dir).join(&article.file))?;
+            .open(path.join(&self.dir).join(article.file))?;
 
-        md_file.write("Hello. Write your article here\n".as_bytes())?;
+        md_file.write_all("Hello. Write your article here\n".as_bytes())?;
         Ok(())
     }
     // Get the description of this issue.

--- a/src/entity/issue.rs
+++ b/src/entity/issue.rs
@@ -51,29 +51,35 @@ impl std::fmt::Debug for Issue {
 }
 
 impl Issue {
+    /// Creates a default Issue struct
     pub(crate) fn new() -> Self {
         Self {
             ..Default::default()
         }
     }
+    /// Set the issue number
     pub(crate) fn set_issue_number(&mut self, number: u32) -> &mut Self {
         self.number = number;
         self
     }
+    /// Set the title of the Issue
     pub(crate) fn set_title(&mut self, title: impl Into<String>) -> &mut Self {
         self.title = title.into();
         self.dir = self.title.clone().to_lowercase().replace(' ', "-");
         self
     }
     #[allow(dead_code)]
+    /// Set the text to be used for the issue's introduction
     fn set_intro(&mut self, intro: impl Into<String>) -> &mut Self {
         self.intro = Some(intro.into());
         self
     }
+    /// Add an article to the issue struct
     pub(crate) fn add_article(&mut self, article: Article) -> &mut Self {
         self.articles.push(article);
         self
     }
+    /// Finalize and return a complete Issue struct
     pub(crate) fn finalize(&mut self) -> Self {
         self.dir = std::format!("{}-{}", &self.dir, &self.number);
         if self.slug.is_empty() {
@@ -81,6 +87,8 @@ impl Issue {
         };
         self.to_owned()
     }
+    /// Create a new directory for the issue
+    /// Should be passed the path to the [ZINE_CONTENT_DIR]
     #[allow(dead_code)]
     pub(crate) fn create_issue_dir(&self, path: &Path) -> Result<()> {
         if path.join(&self.dir).exists() {
@@ -103,6 +111,8 @@ impl Issue {
 
         Ok(())
     }
+    /// Create an emtpy markdown file. This should probably be moved to the article struct
+    /// moving it there would make it easier to use when just adding a new article
     pub(crate) fn write_initial_markdown_file(&mut self, path: &Path) -> Result<()> {
         let article = self.articles[0].meta.finalize();
         let mut md_file = std::fs::OpenOptions::new()

--- a/src/entity/issue.rs
+++ b/src/entity/issue.rs
@@ -24,7 +24,7 @@ pub struct Issue {
     #[serde(skip)]
     pub intro: Option<String>,
     pub cover: Option<String>,
-    /// The path of issue diretory.
+    /// The path of issue directory.
     #[serde(skip_deserializing)]
     pub dir: String,
     /// Skip serialize `articles` since a single article page would
@@ -68,12 +68,6 @@ impl Issue {
         self.dir = self.title.clone().to_lowercase().replace(' ', "-");
         self
     }
-    #[allow(dead_code)]
-    /// Set the text to be used for the issue's introduction
-    fn set_intro(&mut self, intro: impl Into<String>) -> &mut Self {
-        self.intro = Some(intro.into());
-        self
-    }
     /// Add an article to the issue struct
     pub(crate) fn add_article(&mut self, article: Article) -> &mut Self {
         self.articles.push(article);
@@ -81,10 +75,8 @@ impl Issue {
     }
     /// Finalize and return a complete Issue struct
     pub(crate) fn finalize(&mut self) -> Self {
+        // I think this matches the current behavour.
         self.dir = std::format!("{}-{}", &self.dir, &self.number);
-        if self.slug.is_empty() {
-            self.slug = self.dir.clone()
-        };
         self.to_owned()
     }
     /// Create a new directory for the issue
@@ -237,11 +229,7 @@ mod tests {
     #[test]
     fn defaults() {
         let mut issue = Issue::new();
-        issue
-            .set_issue_number(1)
-            .set_title("Some Magical Title")
-            .set_intro("Some magical introduction to some amazing Issue");
-
+        issue.set_issue_number(1).set_title("Some Magical Title");
         let temp_dir = tempdir().unwrap();
         let temp_path = temp_dir.path();
         assert!(std::fs::create_dir_all(&temp_path.join(&issue.dir)).is_ok());

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -22,7 +22,6 @@ pub use list::List;
 pub use markdown::MarkdownConfig;
 pub use page::Page;
 pub use site::Site;
-pub use site::SiteBuilder;
 pub use theme::Theme;
 pub use topic::Topic;
 

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -22,6 +22,7 @@ pub use list::List;
 pub use markdown::MarkdownConfig;
 pub use page::Page;
 pub use site::Site;
+pub use site::SiteBuilder;
 pub use theme::Theme;
 pub use topic::Topic;
 

--- a/src/entity/site.rs
+++ b/src/entity/site.rs
@@ -1,133 +1,10 @@
-use crate::{Article, Issue};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::io::prelude::*;
-use std::{
-    env,
-    path::{Path, PathBuf},
-};
+use std::path::Path;
 use toml;
 
-use crate::{helpers::run_command, ZINE_FILE};
-#[derive(Default)]
-pub struct SiteBuilder {
-    name: Option<String>,
-    source: PathBuf,
-    author: String,
-    site: Site,
-}
-
-impl SiteBuilder {
-    // Defines a new site with default settings while providing a new an optional site `name`
-    pub fn new(name: Option<String>) -> Result<Self> {
-        let source = if let Some(name) = name.as_ref() {
-            env::current_dir()?.join(name)
-        } else {
-            env::current_dir()?
-        };
-        let site_name = name.clone();
-        Ok(Self {
-            name,
-            source: source,
-            site: Site {
-                name: site_name.unwrap_or_default(),
-                ..Site::default()
-            },
-            ..Default::default()
-        })
-    }
-    pub fn create_new_zine_magazine(&mut self) -> Result<()> {
-        // Create Root of Zine Magazine
-        if !self.source.exists() {
-            std::fs::create_dir_all(&self.source)?;
-        }
-        if !self.source.join(crate::ZINE_FILE).exists() {
-
-            // This requires that we add the author struct to Site
-            //let author = run_command("git", &["config", "user.name"])
-            //    .ok()
-            //    .unwrap_or_default();
-            //self.author = author;
-            let content_dir = &self.source.join(crate::ZINE_CONTENT_DIR);
-            self.site.write_toml(&self.source.join(crate::ZINE_FILE))?;
-            std::fs::create_dir_all(&content_dir)?;
-
-            let mut issue = Issue::new();
-            issue.set_title("issue").set_issue_number(1);
-            issue = issue.finalize();
-            issue.create_issue_dir(&content_dir)?;
-
-            let article = Article::default();
-            issue.articles.push(article);
-
-            let issue_dir = &content_dir.join(&issue.dir);
-            let toml_file = &issue_dir
-                .join(crate::ZINE_FILE);
-            // Write Issue zine.toml
-            issue.write_new_issue(&content_dir)?;
-
-            for article in &issue.articles {
-                article.append_article_to_toml(&toml_file)?;
-            }
-
-            if !issue.articles.is_empty() {
-                issue.write_initial_markdown_file(&content_dir)?;
-            }
-        }
-        Ok(())
-    }
-}
-
-#[cfg(test)]
-mod site_builder {
-
-    use super::Site;
-    use super::SiteBuilder;
-    use tempfile::tempdir;
-
-    #[test]
-    fn site_to_build() {
-        let temp_dir = tempdir().unwrap();
-        let site = SiteBuilder::default();
-        assert_eq!(site.name, None);
-        assert_eq!(site.author, "");
-        assert_eq!(site.site.url, "http://localhost");
-
-        let file_path = temp_dir.path().join("dummy.toml");
-        assert!(site.site.write_toml(&file_path.as_path()).is_ok());
-
-        let read_contents = std::fs::read_to_string(&file_path).unwrap();
-        let data: Site = toml::from_str(&read_contents).unwrap();
-
-        assert_eq!(data.name, "My New Magazine Powered by Rust!");
-        assert_eq!(data.url, "http://localhost");
-
-        drop(file_path);
-        assert!(temp_dir.close().is_ok());
-    }
-
-    #[test]
-    fn test_site_builder_new() {
-        let new_site = SiteBuilder::new(Some("test".to_string()));
-        let temp_dir = tempdir().unwrap();
-
-        if let Ok(new_site) = new_site {
-            let file_path = temp_dir.path().join("dummy.toml");
-            assert_eq!(new_site.name, Some("test".to_string()));
-            assert_eq!(new_site.site.name, "test".to_string());
-            assert!(new_site.site.write_toml(&file_path).is_ok());
-
-            let read_contents = std::fs::read_to_string(&file_path).unwrap();
-            let data: Site = toml::from_str(&read_contents).unwrap();
-
-            assert_eq!(data.name, "test");
-            assert_eq!(data.url, "http://localhost");
-
-            drop(file_path);
-            assert!(temp_dir.close().is_ok());
-        }
-    }
-}
+use crate::entity::author::Author;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Site {
@@ -165,7 +42,7 @@ impl Default for Site {
 }
 
 impl Site {
-    fn write_toml(&self, path: &Path) -> Result<()> {
+    pub(crate) fn write_toml(&self, path: &Path) -> Result<()> {
         let mut file = std::fs::OpenOptions::new()
             .write(true)
             .create_new(true)
@@ -173,8 +50,8 @@ impl Site {
 
         let toml_str = toml::to_string(&self)?;
 
+        file.write_all("\n[site]".as_bytes())?;
         file.write_all(toml_str.as_bytes())?;
-
         Ok(())
     }
 }

--- a/src/entity/site.rs
+++ b/src/entity/site.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::io::prelude::*;
 use std::path::Path;
-use toml;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Site {

--- a/src/entity/site.rs
+++ b/src/entity/site.rs
@@ -1,6 +1,84 @@
 use serde::{Deserialize, Serialize};
+use std::io::prelude::*;
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
+use toml;
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+use anyhow::Result;
+
+use crate::ZINE_FILE;
+
+#[derive(Default)]
+struct SiteBuilder {
+    name: Option<String>,
+    source: PathBuf,
+    author: String,
+    site: Site,
+}
+
+impl SiteBuilder {
+    // Defines a new site with default settings while providing a new an optional site `name`
+    fn new(name: Option<String>) -> Result<Self> {
+        let source = if let Some(name) = name.as_ref() {
+            env::current_dir()?.join(name)
+        } else {
+            env::current_dir()?
+        };
+        let site_name = name.clone();
+        Ok(Self {
+            name,
+            source: source,
+            site: Site {
+                name: site_name.unwrap_or("".to_string()),
+                ..Site::default()
+            },
+            ..Default::default()
+        })
+    }
+    fn create_new_zine_dir(&self) -> Result<PathBuf> {
+        if !self.source.exists() {
+            std::fs::create_dir_all(&self.source)?
+        }
+        Ok(self.source.clone())
+    }
+}
+
+#[cfg(test)]
+mod site_builder {
+
+    use super::SiteBuilder;
+    use std::env;
+
+    #[test]
+    fn site_to_build() {
+        let work_space = std::path::Path::new("/tmp");
+        assert!(env::set_current_dir(&work_space).is_ok());
+
+        let site = SiteBuilder::default();
+
+        assert_eq!(site.name, None);
+        assert_eq!(site.author, "");
+        assert_eq!(site.site.url, "http://localhost");
+        assert!(site.create_new_zine_dir().is_ok());
+        assert!(site.site.write_toml(&site.source).is_ok());
+    }
+
+    #[test]
+    fn test_site_builder_new() {
+        let new_site = SiteBuilder::new(Some("test".to_string()));
+
+        if let Ok(new_site) = new_site {
+            assert_eq!(new_site.name, Some("test".to_string()));
+            assert_eq!(new_site.site.name, "test".to_string());
+            assert!(new_site.create_new_zine_dir().is_ok());
+            assert!(new_site.site.write_toml(&new_site.source).is_ok());
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Site {
     /// The absolute url of this site.
     pub url: String,
@@ -18,6 +96,36 @@ pub struct Site {
     #[serde(rename(deserialize = "menu"))]
     #[serde(default)]
     pub menus: Vec<Menu>,
+}
+
+impl Default for Site {
+    fn default() -> Self {
+        Self {
+            url: "http://localhost".into(),
+            cdn: None,
+            name: "My New Magazine Powered by Rust!".into(),
+            description: None,
+            edit_url: None,
+            social_image: None,
+            locale: "en".into(),
+            menus: vec![],
+        }
+    }
+}
+
+impl Site {
+    fn write_toml(&self, path: &Path) -> Result<()> {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(path.join(ZINE_FILE))?;
+
+        let toml_str = toml::to_string(&self)?;
+
+        file.write_all(toml_str.as_bytes())?;
+
+        Ok(())
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/entity/site.rs
+++ b/src/entity/site.rs
@@ -4,8 +4,6 @@ use std::io::prelude::*;
 use std::path::Path;
 use toml;
 
-use crate::entity::author::Author;
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Site {
     /// The absolute url of this site.
@@ -50,7 +48,7 @@ impl Site {
 
         let toml_str = toml::to_string(&self)?;
 
-        file.write_all("\n[site]".as_bytes())?;
+        file.write_all("\n[site]\n".as_bytes())?;
         file.write_all(toml_str.as_bytes())?;
         Ok(())
     }

--- a/src/entity/site.rs
+++ b/src/entity/site.rs
@@ -61,7 +61,7 @@ mod site_builder {
         assert_eq!(site.author, "");
         assert_eq!(site.site.url, "http://localhost");
 
-        let file_path = temp_dir.path().join("dummy.toml").clone();
+        let file_path = temp_dir.path().join("dummy.toml");
         assert!(site.site.write_toml(&file_path.as_path()).is_ok());
 
         let read_contents  = std::fs::read_to_string(&file_path).unwrap();
@@ -82,7 +82,7 @@ mod site_builder {
         let temp_dir = tempdir().unwrap();
 
         if let Ok(new_site) = new_site {
-            let file_path = temp_dir.path().join("dummy.toml").clone();
+            let file_path = temp_dir.path().join("dummy.toml");
             assert_eq!(new_site.name, Some("test".to_string()));
             assert_eq!(new_site.site.name, "test".to_string());
             assert!(new_site.site.write_toml(&file_path).is_ok());

--- a/src/entity/site.rs
+++ b/src/entity/site.rs
@@ -40,6 +40,8 @@ impl Default for Site {
 }
 
 impl Site {
+    /// Writes the site TOML file in the root of the Zine magazine.
+    /// This should only be called when creating a new Zine magazine
     pub(crate) fn write_toml(&self, path: &Path) -> Result<()> {
         let mut file = std::fs::OpenOptions::new()
             .write(true)

--- a/src/entity/zine.rs
+++ b/src/entity/zine.rs
@@ -236,14 +236,14 @@ impl Zine {
         // Sitemap URL must begin with the protocol (such as http)
         // and end with a trailing slash.
         // https://www.sitemaps.org/protocol.html
-        let mut entries = vec![format!("{}/", base_url)];
+        let mut entries = vec![format!("{base_url}/")];
 
         // Issues and articles
         for issue in &self.issues {
             entries.push(format!("{}/{}/", base_url, issue.slug));
             entries.par_extend(issue.articles().par_iter().map(|article| {
                 if let Some(path) = article.meta.path.as_ref() {
-                    format!("{}{}", base_url, path)
+                    format!("{base_url}{path}")
                 } else {
                     format!("{}/{}/{}", base_url, issue.slug, article.meta.slug)
                 }
@@ -251,7 +251,7 @@ impl Zine {
         }
 
         // Authors
-        entries.push(format!("{}/authors/", base_url));
+        entries.push(format!("{base_url}/authors/"));
         entries.par_extend(
             self.authors
                 .par_iter()
@@ -260,7 +260,7 @@ impl Zine {
 
         // Topics
         if !self.topics.is_empty() {
-            entries.push(format!("{}/topics/", base_url));
+            entries.push(format!("{base_url}/topics/"));
             entries.par_extend(
                 self.topics
                     .par_iter()

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,4 +6,6 @@ pub enum ZineError {
     InvalidRootTomlFile(#[from] toml::de::Error),
     #[error("Not a root `zine.toml`, maybe it a `zine.toml` for issue?")]
     NotRootTomlFile,
+    #[error("Invalid Author Id String {0}")]
+    ParseAuthorIdError(String),
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -13,7 +13,7 @@ use std::{
     path::Path,
     process::Command,
 };
-use time::{format_description, OffsetDateTime};
+use time::OffsetDateTime;
 
 pub fn run_command(program: &str, args: &[&str]) -> Result<String, io::Error> {
     let out = Command::new(program).args(args).output()?;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -26,8 +26,8 @@ pub fn run_command(program: &str, args: &[&str]) -> Result<String, io::Error> {
     }
 }
 
-pub fn get_date_of_today() ->  time::Date {
-      OffsetDateTime::now_utc().date()
+pub fn get_date_of_today() -> time::Date {
+    OffsetDateTime::now_utc().date()
 }
 
 pub fn capitalize(text: &str) -> String {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -13,6 +13,7 @@ use std::{
     path::Path,
     process::Command,
 };
+use time::{format_description, OffsetDateTime};
 
 pub fn run_command(program: &str, args: &[&str]) -> Result<String, io::Error> {
     let out = Command::new(program).args(args).output()?;
@@ -23,6 +24,10 @@ pub fn run_command(program: &str, args: &[&str]) -> Result<String, io::Error> {
             format!("run command `{program} {}` failed.", args.join(" ")),
         )),
     }
+}
+
+pub fn get_date_of_today() ->  time::Date {
+      OffsetDateTime::now_utc().date()
 }
 
 pub fn capitalize(text: &str) -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub mod serve;
 
 pub use self::engine::ZineEngine;
 pub use self::entity::Entity;
-
+pub use self::entity::{SiteBuilder, Site, Issue, MetaArticle, Article};
 /// The convention name of zine config file.
 pub static ZINE_FILE: &str = "zine.toml";
 /// The convention name of zine markdown directory.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub mod serve;
 
 pub use self::engine::ZineEngine;
 pub use self::entity::Entity;
-pub use self::entity::{ Site, Issue, MetaArticle, Article, AuthorId, Author};
+pub use self::entity::{Article, Author, AuthorId, Issue, MetaArticle, Site};
 /// The convention name of zine config file.
 pub static ZINE_FILE: &str = "zine.toml";
 /// The convention name of zine markdown directory.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub mod serve;
 
 pub use self::engine::ZineEngine;
 pub use self::entity::Entity;
-pub use self::entity::{SiteBuilder, Site, Issue, MetaArticle, Article};
+pub use self::entity::{ Site, Issue, MetaArticle, Article, AuthorId, Author};
 /// The convention name of zine config file.
 pub static ZINE_FILE: &str = "zine.toml";
 /// The convention name of zine markdown directory.

--- a/src/locales.rs
+++ b/src/locales.rs
@@ -22,11 +22,11 @@ impl FluentLoader {
             "zh" => FluentResource::try_new(FLUENT_ZH_CN.to_owned()),
             _ => {
                 // Not a buitlin locale, load the user translation resource.
-                let file = format!("locales/{}.ftl", locale);
+                let file = format!("locales/{locale}.ftl");
                 let path = source.join(&file);
                 if path.exists() {
                     let translation = fs::read_to_string(path)
-                        .unwrap_or_else(|err| panic!("{file} read failed: {}", err));
+                        .unwrap_or_else(|err| panic!("{file} read failed: {err}"));
                     FluentResource::try_new(translation)
                 } else {
                     println!("Warning: `{file}` does not exist, please add your translation to this file.");
@@ -69,7 +69,7 @@ impl tera::Function for FluentLoader {
         let pattern = self
             .bundle
             .get_message(key)
-            .unwrap_or_else(|| panic!("Invalid fluent key: `{}`", key))
+            .unwrap_or_else(|| panic!("Invalid fluent key: `{key}`"))
             .value()
             .expect("Missing Value.");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,12 @@ async fn main() -> Result<()> {
         }
         Commands::New { name, issue } => {
             if issue {
-                new_zine_issue()?;
+                match new_zine_issue() {
+                    Err(_) => eprintln!(
+                        "You have tried to create an issue that already exists.\nNothing created."
+                    ),
+                    _ => {}
+                }
             } else {
                 new_zine_project(name)?
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use zine::build::watch_build;
 use zine::new::{new_zine_issue, new_zine_project};
 use zine::serve::run_serve;
 use zine::{lint, Mode};
+use zine::{SiteBuilder, Site, Issue, MetaArticle, Article};
 
 #[derive(Debug, Parser)]
 #[command(name = "zine")]
@@ -74,7 +75,9 @@ async fn main() -> Result<()> {
             if issue {
                 new_zine_issue()?;
             } else {
-                new_zine_project(name)?
+                let site = SiteBuilder::new(name)?;
+                let _path_buf = site.create_new_zine_magazine();
+                //new_zine_project(name)?
             }
         }
         Commands::Lint { source, ci } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use zine::build::watch_build;
-use zine::new::{SiteBuilder, new_zine_issue};
+use zine::new::{new_zine_issue, new_zine_project};
 use zine::serve::run_serve;
 use zine::{lint, Mode};
 
@@ -74,9 +74,7 @@ async fn main() -> Result<()> {
             if issue {
                 new_zine_issue()?;
             } else {
-                let mut site = SiteBuilder::new(name)?;
-                site.create_new_zine_magazine()?;
-                //new_zine_project(name)?
+                new_zine_project(name)?
             }
         }
         Commands::Lint { source, ci } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,9 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use zine::build::watch_build;
-use zine::new::{new_zine_issue, new_zine_project};
+use zine::new::{SiteBuilder, new_zine_issue};
 use zine::serve::run_serve;
 use zine::{lint, Mode};
-use zine::{SiteBuilder, Site, Issue, MetaArticle, Article};
 
 #[derive(Debug, Parser)]
 #[command(name = "zine")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,8 +75,8 @@ async fn main() -> Result<()> {
             if issue {
                 new_zine_issue()?;
             } else {
-                let site = SiteBuilder::new(name)?;
-                let _path_buf = site.create_new_zine_magazine();
+                let mut site = SiteBuilder::new(name)?;
+                site.create_new_zine_magazine()?;
                 //new_zine_project(name)?
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ async fn main() -> Result<()> {
             zine::set_current_mode(Mode::Build);
             let dest = dest.unwrap_or_else(|| "build".into());
             watch_build(&source.unwrap_or_else(|| ".".into()), &dest, watch, None).await?;
-            println!("Build success! The build directory is `{}`.", dest);
+            println!("Build success! The build directory is `{dest}`.");
         }
         Commands::Serve { source, port } => {
             zine::set_current_mode(Mode::Serve);
@@ -89,8 +89,8 @@ async fn main() -> Result<()> {
             let date = option_env!("LAST_COMMIT_DATE").unwrap_or("");
             let build_info = env!("BUILD_INFO");
             println!("{}", zine::ZINE_BANNER);
-            println!("Zine version {} {}", version, date);
-            println!("({})", build_info);
+            println!("Zine version {version} {date}");
+            println!("({build_info})");
         }
     }
     Ok(())

--- a/src/markdown/render.rs
+++ b/src/markdown/render.rs
@@ -258,7 +258,7 @@ impl<'a> MarkdownRender<'a> {
                 let html = self.highlight_syntax(fenced.name, text);
                 return Visiting::Event(Event::Html(html.into()));
             } else {
-                return Visiting::Event(Event::Html(format!("<pre>{}</pre>", text).into()));
+                return Visiting::Event(Event::Html(format!("<pre>{text}</pre>").into()));
             }
         }
 

--- a/src/new.rs
+++ b/src/new.rs
@@ -21,7 +21,7 @@ impl ZineScaffold {
             ..Default::default()
         };
         let author = Author {
-            name: Some(self.author.clone().to_lowercase()),
+            name: Some(self.author.clone()),
             id: self.author.to_lowercase(),
             ..Default::default()
         };
@@ -81,7 +81,7 @@ pub fn new_zine_project(name: Option<String>) -> Result<()> {
         source,
         author,
         issue_number: 1,
-        issue_title: "Issue 1".into(),
+        issue_title: "Issue".into(),
     };
 
     scaffold.create_project(&name.unwrap_or_default())?;

--- a/src/new.rs
+++ b/src/new.rs
@@ -1,59 +1,38 @@
+use std::io::prelude::*;
 use std::{borrow::Cow, env, fs, path::PathBuf};
 
 use anyhow::{Context as _, Result};
 use promptly::prompt_default;
-use tera::{Context, Tera};
-use time::{format_description, OffsetDateTime};
 
 use crate::{helpers::run_command, ZINE_FILE};
-use crate::{AuthorId, Author, Article, Issue, Site};
-
-static TEMPLATE_PROJECT_FILE: &str = r#"
-[site]
-url = "http://localhost"
-name = "{{ name }}"
-description = ""
-
-[authors]
-{% if author -%}
-{{ author | lower }} = { name = "{{ author }}" }
-{% endif -%}
-"#;
-
-static TEMPLATE_ISSUE_FILE: &str = r#"
-slug = "{{ slug }}"
-number = {{ number }}
-title = "{{ title }}"
-
-[[article]]
-file = "1-first.md"
-title = "First article"
-author = "{{ author | lower }}"
-cover = ""
-pub_date = "{{ pub_date }}"
-publish = true
-featured = true
-"#;
+use crate::{Article, Author, Issue, Site};
 
 struct ZineScaffold {
     source: PathBuf,
     author: String,
-    issue_dir: Cow<'static, str>,
-    issue_number: usize,
+    issue_number: u32,
     issue_title: Cow<'static, str>,
 }
 
 impl ZineScaffold {
     fn create_project(&self, name: &str) -> Result<()> {
-        let mut context = Context::new();
-        context.insert("name", name);
-        context.insert("author", &self.author);
+        let site = Site {
+            name: name.into(),
+            ..Default::default()
+        };
+        let author = Author {
+            name: Some(self.author.clone().to_lowercase()),
+            id: self.author.to_lowercase(),
+            ..Default::default()
+        };
+        site.write_toml(&self.source.join(ZINE_FILE))?;
 
-        // Generate project zine.toml
-        fs::write(
-            self.source.join(ZINE_FILE),
-            Tera::one_off(TEMPLATE_PROJECT_FILE, &context, true)?,
-        )?;
+        // Appending Author to site zine.toml
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&self.source.join(crate::ZINE_FILE))?;
+        file.write_all("\n[authors]\n".as_bytes())?;
+        file.write_all(author.to_string().as_bytes())?;
 
         // Create issue dir and issue zine.toml
         self.create_issue()?;
@@ -62,28 +41,26 @@ impl ZineScaffold {
 
     // Create issue dir and issue zine.toml
     fn create_issue(&self) -> Result<()> {
-        let issue_dir = self
-            .source
-            .join(crate::ZINE_CONTENT_DIR)
-            .join(self.issue_dir.as_ref());
-        fs::create_dir_all(&issue_dir)?;
-        let format = format_description::parse("[year]-[month]-[day]")?;
-        let today = OffsetDateTime::now_utc().format(&format)?;
+        let contents_dir = self.source.join(crate::ZINE_CONTENT_DIR);
 
-        let mut context = Context::new();
-        context.insert("slug", &self.issue_dir);
-        context.insert("number", &self.issue_number);
-        context.insert("title", &self.issue_title);
-        context.insert("pub_date", &today);
-        context.insert("author", &self.author);
+        let mut issue = Issue::new()
+            .set_title(self.issue_title.clone())
+            .set_issue_number(self.issue_number)
+            .finalize();
+        println!("{:?}", issue);
+        fs::create_dir_all(&contents_dir.join(&issue.dir))?;
+        let mut article = Article::default();
+        article.meta.set_authors(&self.author)?.finalize();
+        article.finalize();
+        issue.add_article(article);
+        issue.write_new_issue(&contents_dir)?;
 
-        fs::write(
-            issue_dir.join(ZINE_FILE),
-            Tera::one_off(TEMPLATE_ISSUE_FILE, &context, true)?,
-        )?;
+        if !issue.articles.is_empty() {
+            issue.write_initial_markdown_file(&contents_dir)?;
+            issue.articles[0]
+                .append_article_to_toml(&contents_dir.join(issue.dir).join(ZINE_FILE))?;
+        }
 
-        // Create first article
-        fs::write(issue_dir.join("1-first.md"), "Hello Zine")?;
         Ok(())
     }
 }
@@ -104,7 +81,6 @@ pub fn new_zine_project(name: Option<String>) -> Result<()> {
     let scaffold = ZineScaffold {
         source,
         author,
-        issue_dir: "issue-1".into(),
         issue_number: 1,
         issue_title: "Issue 1".into(),
     };
@@ -123,141 +99,16 @@ pub fn new_zine_issue() -> Result<()> {
         .ok()
         .unwrap_or_default();
     let next_issue_number = zine.issues.len() + 1;
-    let issue_dir = prompt_default(
-        "What is your issue directory name?",
-        format!("issue-{next_issue_number}"),
-    )?;
+
     let issue_number = prompt_default("What is your issue number?", next_issue_number)?;
-    let issue_title = prompt_default(
-        "What is your issue title?",
-        format!("Issue {next_issue_number}"),
-    )?;
+    let issue_title = prompt_default("What is your issue title?", format!("Issue"))?;
 
     let scaffold = ZineScaffold {
         source,
         author,
-        issue_dir: issue_dir.into(),
-        issue_number,
+        issue_number: issue_number.try_into().unwrap(),
         issue_title: issue_title.into(),
     };
     scaffold.create_issue()?;
     Ok(())
-}
-
-#[derive(Default)]
-pub struct SiteBuilder {
-    source: PathBuf,
-    site: Site,
-}
-
-impl SiteBuilder {
-    // Defines a new site with default settings while providing a new an optional site `name`
-    pub fn new(name: Option<String>) -> Result<Self> {
-        let source = if let Some(name) = name.as_ref() {
-            env::current_dir()?.join(name)
-        } else {
-            env::current_dir()?
-        };
-        Ok(Self {
-            source,
-            site: Site {
-                name: name.unwrap_or_default(),
-                ..Site::default()
-            },
-            ..Default::default()
-        })
-    }
-    pub fn create_new_zine_magazine(&mut self) -> Result<()> {
-        // Create Root of Zine Magazine
-        if !self.source.exists() {
-            std::fs::create_dir_all(&self.source)?;
-        }
-        if !self.source.join(crate::ZINE_FILE).exists() {
-            // This requires that we add the author struct to Site
-            /*
-            let author = run_command("git", &["config", "user.name"])
-                .ok()
-                .unwrap_or_default();
-            let author_id = author.parse::<AuthorId>()?;
-            let author = Author {
-                id: serde_json::to_string(&author_id).unwrap().to_lowercase(),
-                ..Default::default()
-            };
-            self.site.authors.push(author);
-            */
-            let content_dir = &self.source.join(crate::ZINE_CONTENT_DIR);
-            self.site.write_toml(&self.source.join(crate::ZINE_FILE))?;
-            std::fs::create_dir_all(&content_dir)?;
-
-            let mut issue = Issue::new();
-            issue.set_title("issue").set_issue_number(1);
-            issue = issue.finalize();
-            issue.create_issue_dir(&content_dir)?;
-
-            let article = Article::default();
-            issue.articles.push(article);
-
-            let issue_dir = &content_dir.join(&issue.dir);
-            let toml_file = &issue_dir.join(crate::ZINE_FILE);
-            // Write Issue zine.toml
-            issue.write_new_issue(&content_dir)?;
-
-            for article in &issue.articles {
-                article.append_article_to_toml(&toml_file)?;
-            }
-
-            if !issue.articles.is_empty() {
-                issue.write_initial_markdown_file(&content_dir)?;
-            }
-        }
-        Ok(())
-    }
-}
-
-#[cfg(test)]
-mod site_builder {
-
-    use super::Site;
-    use super::SiteBuilder;
-    use tempfile::tempdir;
-
-    #[test]
-    fn site_to_build() {
-        let temp_dir = tempdir().unwrap();
-        let site = SiteBuilder::default();
-        assert_eq!(site.site.url, "http://localhost");
-
-        let file_path = temp_dir.path().join("dummy.toml");
-        assert!(site.site.write_toml(&file_path.as_path()).is_ok());
-
-        let read_contents = std::fs::read_to_string(&file_path).unwrap();
-        let data: Site = toml::from_str(&read_contents).unwrap();
-
-        assert_eq!(data.name, "My New Magazine Powered by Rust!");
-        assert_eq!(data.url, "http://localhost");
-
-        drop(file_path);
-        assert!(temp_dir.close().is_ok());
-    }
-
-    #[test]
-    fn test_site_builder_new() {
-        let new_site = SiteBuilder::new(Some("test".to_string()));
-        let temp_dir = tempdir().unwrap();
-
-        if let Ok(new_site) = new_site {
-            let file_path = temp_dir.path().join("dummy.toml");
-            assert_eq!(new_site.site.name, "test".to_string());
-            assert!(new_site.site.write_toml(&file_path).is_ok());
-
-            let read_contents = std::fs::read_to_string(&file_path).unwrap();
-            let data: Site = toml::from_str(&read_contents).unwrap();
-
-            assert_eq!(data.name, "test");
-            assert_eq!(data.url, "http://localhost");
-
-            drop(file_path);
-            assert!(temp_dir.close().is_ok());
-        }
-    }
 }

--- a/src/new.rs
+++ b/src/new.rs
@@ -30,7 +30,7 @@ impl ZineScaffold {
         // Appending Author to site zine.toml
         let mut file = std::fs::OpenOptions::new()
             .append(true)
-            .open(&self.source.join(crate::ZINE_FILE))?;
+            .open(self.source.join(crate::ZINE_FILE))?;
         file.write_all("\n[authors]\n".as_bytes())?;
         file.write_all(author.to_string().as_bytes())?;
 
@@ -47,8 +47,7 @@ impl ZineScaffold {
             .set_title(self.issue_title.clone())
             .set_issue_number(self.issue_number)
             .finalize();
-        println!("{:?}", issue);
-        fs::create_dir_all(&contents_dir.join(&issue.dir))?;
+        fs::create_dir_all(contents_dir.join(&issue.dir))?;
         let mut article = Article::default();
         article.meta.set_authors(&self.author)?.finalize();
         article.finalize();
@@ -101,7 +100,7 @@ pub fn new_zine_issue() -> Result<()> {
     let next_issue_number = zine.issues.len() + 1;
 
     let issue_number = prompt_default("What is your issue number?", next_issue_number)?;
-    let issue_title = prompt_default("What is your issue title?", format!("Issue"))?;
+    let issue_title = prompt_default("What is your issue title?", "Issue".to_string())?;
 
     let scaffold = ZineScaffold {
         source,

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -37,8 +37,8 @@ pub async fn run_serve(source: String, port: u16) -> Result<()> {
             .unwrap();
     });
 
-    println!("{}", ZINE_BANNER);
-    println!("listening on http://{}", addr);
+    println!("{ZINE_BANNER}");
+    println!("listening on http://{addr}");
     hyper::Server::bind(&addr)
         .serve(tower::make::Shared::new(serve_dir))
         .await


### PR DESCRIPTION
- Refactor: how Site struct is created
- Feat: Add a way to create a new issue by chaining
- Commit to Support new Article features
- Clippy and formating fixes
- Add tempdir crate for testing toml file read/write
- Refactor: Tests to use tempdir crate
- Re-import modules
- Create Site and default article
- Refactor: Move SiteBuilder to new.rs file
- Feature: Implement Display for Author
- Documentation for new code

This commit also removes the need for tera and time from the new.rs file.
the toml crate is used to write the zine.toml files instead. This means that changing the structs will ensure that zine files are written correctly.
