### PR TITLE
fix date format panic

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -142,17 +142,15 @@ pub mod serde_date {
         type Value = Date;
 
         fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-            formatter.write_str("a date value like YYYY-MM-dd")
+            formatter.write_str("The date format is YYYY-MM-DD")
         }
 
         fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
         where
             E: de::Error,
         {
-            let format =
-                format_description::parse("[year]-[month]-[day]").expect("Shouldn't happen");
-            Ok(Date::parse(v, &format)
-                .unwrap_or_else(|_| panic!("The date value {} is invalid", &v)))
+            let format = format_description::parse("[year]-[month]-[day]").expect("Shouldn't happen");
+            Date::parse(v, &format).map_err(|e| E::custom(format!("The date value {} is invalid: {}", v, e)))
         }
     }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -149,8 +149,10 @@ pub mod serde_date {
         where
             E: de::Error,
         {
-            let format = format_description::parse("[year]-[month]-[day]").expect("Shouldn't happen");
-            Date::parse(v, &format).map_err(|e| E::custom(format!("The date value {} is invalid: {}", v, e)))
+            let format =
+                format_description::parse("[year]-[month]-[day]").expect("Shouldn't happen");
+            Date::parse(v, &format)
+                .map_err(|e| E::custom(format!("The date value {} is invalid: {}", v, e)))
         }
     }
 }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -32,9 +32,13 @@ pub async fn run_serve(source: String, port: u16) -> Result<()> {
     let serve_dir = ServeDir::new(&tmp_dir).fallback(FallbackService { tx: tx.clone() });
 
     tokio::spawn(async move {
-        watch_build(Path::new(&source), tmp_dir.as_path(), true, Some(tx))
-            .await
-            .unwrap();
+        match watch_build(Path::new(&source), tmp_dir.as_path(), true, Some(tx)).await {
+            Ok(result) => result,
+            Err(e) => {
+                // handle the error here, for example by logging it or returning it to the caller
+                println!("Error: {:?}", e);
+            }
+        };
     });
 
     println!("{}", ZINE_BANNER);


### PR DESCRIPTION
- Remove: unwrap() as this may fail
- Fix: Because Date parsers can fail, match case

The code will still panic in `debug` mode. It will close cleanly in production

```sh


███████╗██╗███╗   ██╗███████╗
╚══███╔╝██║████╗  ██║██╔════╝
  ███╔╝ ██║██╔██╗ ██║█████╗  
 ███╔╝  ██║██║╚██╗██║██╔══╝  
███████╗██║██║ ╚████║███████╗
╚══════╝╚═╝╚═╝  ╚═══╝╚══════╝
                             

listening on http://127.0.0.1:3000
Error: The date value 2023-1-31 is invalid: the 'month' component could not be parsed for key `article` at line 6 column 1
```
This should close #164 